### PR TITLE
Added configuration template

### DIFF
--- a/config/ibmiuseradmin.global.php.dist
+++ b/config/ibmiuseradmin.global.php.dist
@@ -1,0 +1,24 @@
+<?php
+/**
+ * IBM i User Admin Configuration
+ *
+ * If you have a ./config/autoload/ directory set up for your project, you can
+ * drop this config file in it and change the values as you wish.
+ */
+$settings = array(
+
+    'zend_db_adapter' => 'Zend\Db\Adapter\Adapter',
+
+);
+
+/**
+ * You do not need to edit below this line
+ */
+return array(
+    'ibmiuseradmin' => $settings,
+    'service_manager' => array(
+        'aliases' => array(
+            'ibmiuseradmin_zend_db_adapter' => (isset($settings['zend_db_adapter'])) ? $settings['zend_db_adapter']: 'Zend\Db\Adapter\Adapter',
+        ),
+    ),
+);


### PR DESCRIPTION
Added ibmiuseradmin.global.php.dist to /config with the intent that users will copy it to the /config/autoload directory in their project and remove the ".dist" suffix. Then they'll customize it as they wish. This file will enable us to create and use services and config options specific to this module.